### PR TITLE
Add plugin: tune_checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ My public plugins for OWRX+.
 Every plugin has it's own documentation.  
 
 ### receiver plugins
- - [frequency_far_jump](receiver/frequency_far_jump/) - jump to a frequency outside of the current profile, by typing it in the receiver's frequency dial. (LZ2DMV)
+ - [tune_checkbox](receiver/tune_checkbox/) - make the 'Hold mouse wheel down to tune' setting enabled by default (LZ2DMV)
+ - [frequency_far_jump](receiver/frequency_far_jump/) - jump to a frequency outside of the current profile, by typing it in the receiver's frequency dial (LZ2DMV)
  - [keyboard_shortcuts](receiver/keyboard_shortcuts/) - add keyboard shortcuts to the receiver
  - [colorful_spectrum](receiver/colorful_spectrum/) - colorize the spectrum analyzer
  - [connect_notify](receiver/connect_notify/) - send/receive notifications on user connect/disconnect

--- a/receiver/tune_checkbox/README.md
+++ b/receiver/tune_checkbox/README.md
@@ -1,0 +1,14 @@
+# OWRX+ Receiver Plugin: tune_checkbox
+
+This a one-line `receiver` plugin to make the 'Hold mouse wheel down to tune' setting enabled by default.
+
+This setting allows you to use the mouse scroll to zoom into the waterfall.
+
+# load
+Add this lines in your `init.js` file:
+```js
+Plugins.load('https://0xaf.github.io/openwebrxplus-plugins/receiver/tune_checkbox/tune_checkbox.js');
+```
+
+# init.js
+You can find more info on `init.js` [on GitHub pages](https://0xaf.github.io/openwebrxplus-plugins/) or directly in [0xAF's GitHub repo](https://github.com/0xAF/openwebrxplus-plugins).

--- a/receiver/tune_checkbox/tune_checkbox.js
+++ b/receiver/tune_checkbox/tune_checkbox.js
@@ -1,0 +1,11 @@
+/*
+ * Plugin: Make the 'Hold mouse wheel down to tune' option checked by default.
+ * Allows you to zoom into the waterfall with the mouse scroll.
+
+ * License: Apache License 2.0
+ * Copyright (c) 2024 Dimitar Milkov, LZ2DMV
+ */
+
+Plugins.tune_checkbox.no_css = true;
+
+$('#openwebrx-wheel-checkbox').prop('checked', true).change();


### PR DESCRIPTION
Two lines of a plugin, but still worth to have.

Makes the 'Hold mouse wheel down to tune' option enabled by default.

Most people want to zoom into the waterfall with the mouse scroll and It is annoying to click it every time.