### PR TITLE
Fix colorful_spectrum

### DIFF
--- a/receiver/colorful_spectrum/colorful_spectrum.js
+++ b/receiver/colorful_spectrum/colorful_spectrum.js
@@ -49,7 +49,7 @@ Plugins.colorful_spectrum.init = async function () {
             var y = (data - thisArg.min) * y_ratio;
             thisArg.ctx.fillRect(x, spec_height, 1, -y);
             if (data) {
-              var c = waterfall_mkcolor(data);
+              var c = Waterfall.makeColor(data);
               thisArg.ctx.fillStyle = "rgba(" +
                 c[0] + ", " + c[1] + ", " + c[2] + ", " +
                 (25 + y * 2) + "%)";


### PR DESCRIPTION
Update the reference to the new implementation of the **waterfall_mkcolor** function in the ([Waterfall.makeColor](https://github.com/luarvique/openwebrx/blob/8177ffa20e70f65c71f979fc7e573ae41b5f33a4/htdocs/lib/Waterfall.js#L167)) method.